### PR TITLE
Route migrator

### DIFF
--- a/src/Commands/MigrateRoutes.php
+++ b/src/Commands/MigrateRoutes.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Statamic\Migrator\Commands;
+
+use Statamic\Console\RunsInPlease;
+use Statamic\Migrator\RoutesMigrator;
+
+class MigrateRoutes extends Command
+{
+    use RunsInPlease;
+
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $name = 'statamic:migrate:routes';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Migrate v2 routes';
+
+    /**
+     * Runs migrator.
+     *
+     * @var string
+     */
+    protected $migrator = RoutesMigrator::class;
+
+    /**
+     * Get the console command arguments.
+     *
+     * @return array
+     */
+    protected function getArguments()
+    {
+        return [];
+    }
+}

--- a/src/RoutesMigrator.php
+++ b/src/RoutesMigrator.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace Statamic\Migrator;
+
+use Statamic\Support\Arr;
+use Statamic\Support\Str;
+use Symfony\Component\VarExporter\VarExporter;
+
+class RoutesMigrator extends Migrator
+{
+    use Concerns\MigratesFile,
+        Concerns\ThrowsFinalWarnings;
+
+    /**
+     * Perform migration.
+     */
+    public function migrate()
+    {
+        return $this->migrateRoutes()->throwFinalWarnings();
+    }
+
+    /**
+     * Perform migration on routes.
+     *
+     * @return $this
+     */
+    protected function migrateRoutes()
+    {
+        $routes = $this->getSourceYaml($this->sitePath('settings/routes.yaml'));
+
+        $php = $this->files->exists($path = base_path('routes/web.php'))
+            ? $this->files->get($path)
+            : '<?php';
+
+        $str = $php . "\n\n"
+            . $this->getRegularRoutes($routes['routes'] ?? []) . "\n\n"
+            . $this->getVanityRedirects($routes['vanity'] ?? []) . "\n\n"
+            . $this->getPermanentRedirects($routes['redirect'] ?? []);
+
+        $str = rtrim($str) . "\n";
+
+        $this->files->put($path, $str);
+
+        return $this;
+    }
+
+    protected function getRegularRoutes($routes)
+    {
+        return collect($routes)
+            ->map(function ($route) {
+                return is_array($route) ? $route : ['template' => $route];
+            })
+            ->map(function ($route, $uri) {
+                if (! $view = Arr::pull($route, 'template')) {
+                    $this->addWarning("Route [$uri] was not migrated because it has no template.");
+                    return null;
+                }
+
+                $str = vsprintf("Route::statamic('%s', '%s'", [
+                    $this->removeLeadingSlash($uri),
+                    str_replace('/', '.', $view)
+                ]);
+
+                if (! empty($route)) {
+                    $str .= ', ' . VarExporter::export($route);
+                }
+
+                $str .= ');';
+
+                return $str;
+            })
+            ->filter()
+            ->join("\n");
+    }
+
+    protected function getVanityRedirects($redirects)
+    {
+        return collect($redirects)->map(function ($to, $from) {
+            return vsprintf("Route::redirect('%s', '%s');", [
+                $this->removeLeadingSlash($from),
+                $this->removeLeadingSlash($to),
+            ]);
+        })->join("\n");
+    }
+
+    protected function getPermanentRedirects($redirects)
+    {
+        return collect($redirects)->map(function ($to, $from) {
+            return vsprintf("Route::permanentRedirect('%s', '%s');", [
+                $this->removeLeadingSlash($from),
+                $this->removeLeadingSlash($to),
+            ]);
+        })->join("\n");
+    }
+
+    protected function removeLeadingSlash($str)
+    {
+        $str = Str::removeLeft($str, '/');
+        return $str === '' ? '/' : $str;
+    }
+}

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -16,6 +16,7 @@ class ServiceProvider extends AddonServiceProvider
         Commands\MigrateGroups::class,
         Commands\MigratePages::class,
         Commands\MigrateRoles::class,
+        Commands\MigrateRoutes::class,
         Commands\MigrateSettings::class,
         Commands\MigrateSite::class,
         Commands\MigrateTaxonomy::class,

--- a/src/SettingsMigrator.php
+++ b/src/SettingsMigrator.php
@@ -24,7 +24,6 @@ class SettingsMigrator extends Migrator
             ->migrateCp()
             // ->migrateDebug()
             // ->migrateEmail()
-            ->migrateRoutes()
             // ->migrateSearch()
             ->migrateSystem()
             // ->migrateTheming()
@@ -47,24 +46,6 @@ class SettingsMigrator extends Migrator
         Configurator::file('statamic/cp.php')->set('date_format', $cp['date_format'] ?? false);
         Configurator::file('statamic/cp.php')->merge('widgets', $cp['widgets'] ?? []);
         Configurator::file('statamic/cp.php')->set('pagination_size', $cp['pagination_size'] ?? false);
-
-        return $this;
-    }
-
-    /**
-     * Perform migration on routes.
-     *
-     * @return $this
-     */
-    protected function migrateRoutes()
-    {
-        $this->validate('routes.php');
-
-        $routes = $this->parseSettingsFile('routes.yaml');
-
-        Configurator::file('statamic/routes.php')->merge('routes', $routes['routes'] ?? []);
-        Configurator::file('statamic/routes.php')->merge('vanity', $routes['vanity'] ?? []);
-        Configurator::file('statamic/routes.php')->merge('redirect', $routes['redirect'] ?? []);
 
         return $this;
     }

--- a/tests/Fixtures/site/settings/routes.yaml
+++ b/tests/Fixtures/site/settings/routes.yaml
@@ -5,7 +5,8 @@ taxonomies:
   tags: '/blog/tags/{slug}'
 routes:
   /search: search
-  /blog/tags: blog/taxonomies
+  /route-with-no-template:
+    foo: bar
   /blog/feed:
     layout: feed
     template: feeds/blog

--- a/tests/MigrateRoutesTest.php
+++ b/tests/MigrateRoutesTest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Tests;
+
+use Tests\TestCase;
+use Facades\Statamic\Console\Processes\Process;
+
+class MigrateRoutesTest extends TestCase
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        Process::swap(new \Statamic\Console\Processes\Process(__DIR__ . '/../'));
+    }
+
+    /** @test */
+    function it_migrates_routes()
+    {
+        @mkdir(base_path('routes'));
+        file_put_contents($path = base_path('routes/web.php'), <<<EOT
+<?php
+
+// Route::get('/', function () {
+//     return view('welcome');
+// });
+EOT);
+
+        $this->artisan('statamic:migrate:routes');
+
+        $expected = <<<EOT
+<?php
+
+// Route::get('/', function () {
+//     return view('welcome');
+// });
+
+Route::statamic('search', 'search');
+Route::statamic('blog/feed', 'feeds.blog', [
+    'layout' => 'feed',
+    'content_type' => 'atom',
+]);
+
+Route::redirect('products', 'products-old');
+
+Route::permanentRedirect('articles', '/');
+Route::permanentRedirect('blog/posts', 'blog');
+
+EOT;
+
+        $this->assertFileHasContent($expected, $path);
+        // TODO: Assert about warning when a route has no template.
+    }
+}

--- a/tests/MigrateSettingsTest.php
+++ b/tests/MigrateSettingsTest.php
@@ -69,43 +69,6 @@ EOT
     }
 
     /** @test */
-    function it_migrates_routes()
-    {
-        $this->artisan('statamic:migrate:settings', ['handle' => 'routes']);
-
-        $this->assertConfigFileContains('routes.php', <<<EOT
-    'routes' => [
-        // '/' => 'home'
-        '/search' => 'search',
-        '/blog/tags' => 'blog/taxonomies',
-        '/blog/feed' => [
-            'layout' => 'feed',
-            'template' => 'feeds/blog',
-            'content_type' => 'atom',
-        ],
-    ],
-EOT
-        );
-
-        $this->assertConfigFileContains('routes.php', <<<EOT
-    'vanity' => [
-        // '/promo' => '/blog/2019/09/big-sale-on-hot-dogs',
-        '/products' => '/products-old',
-    ],
-EOT
-        );
-
-        $this->assertConfigFileContains('routes.php', <<<EOT
-    'redirect' => [
-        // '/here' => '/there',
-        '/articles' => '/',
-        '/blog/posts' => '/blog',
-    ],
-EOT
-        );
-    }
-
-    /** @test */
     function it_migrates_system_settings()
     {
         $this->artisan('statamic:migrate:settings', ['handle' => 'system']);


### PR DESCRIPTION
Instead of migrating `routes.yaml` into `config/statamic/routes.php`, it now creates route definitions in `routes/web.php`.

Relies on https://github.com/statamic/cms/pull/1275 being merged and tagged.