### PR TITLE
Multisite pages migration fixes

### DIFF
--- a/src/PagesMigrator.php
+++ b/src/PagesMigrator.php
@@ -354,7 +354,10 @@ class PagesMigrator extends Migrator
      */
     protected function getPageFieldset($page)
     {
+        $origin = $this->getOriginEntry($page);
+
         $fieldset = $page['fieldset']
+            ?? $origin['fieldset']
             ?? $this->getSetting('theming.default_page_fieldset')
             ?? $this->getSetting('theming.default_fieldset');
 
@@ -466,5 +469,18 @@ class PagesMigrator extends Migrator
         return $depth === 1
             ? ['tree' => $normalized]
             : $normalized;
+    }
+
+    /**
+     * Get origin entry for localized entry.
+     *
+     * @param array $localizedEntry
+     * @return null|array
+     */
+    protected function getOriginEntry($localizedEntry)
+    {
+        return collect($this->entries)->first(function ($entry) use ($localizedEntry) {
+            return $entry['id'] === Arr::get($localizedEntry, 'origin');
+        });
     }
 }

--- a/src/PagesMigrator.php
+++ b/src/PagesMigrator.php
@@ -130,7 +130,7 @@ class PagesMigrator extends Migrator
      */
     protected function parseLocalizedPagesInFolder($folder, $pageOrigin)
     {
-        $entries = $this->getLocalizedPagesInFolder($folder)
+        $this->getLocalizedPagesInFolder($folder)
             ->map(function ($page, $site) use ($pageOrigin) {
                 return array_merge($page, [
                     'origin' => $pageOrigin['id'],
@@ -173,7 +173,7 @@ class PagesMigrator extends Migrator
      */
     protected function getLocalizedPagesInFolder($folder)
     {
-        return collect($this->files->files($folder))
+        $explicitlyLocalizedPages = collect($this->files->files($folder))
             ->keyBy
             ->getFilenameWithoutExtension()
             ->filter(function ($file, $filename) {
@@ -188,6 +188,15 @@ class PagesMigrator extends Migrator
             ->map(function ($page) {
                 return YAML::parse($page->getContents());
             });
+
+        $implicitlyLocalizedPages = collect($this->sites)
+            ->flip()
+            ->forget('default')
+            ->map(function ($page) {
+                return [];
+            });
+
+        return $implicitlyLocalizedPages->merge($explicitlyLocalizedPages);
     }
 
     /**

--- a/src/PagesMigrator.php
+++ b/src/PagesMigrator.php
@@ -132,12 +132,12 @@ class PagesMigrator extends Migrator
     {
         $this->getLocalizedPagesInFolder($folder)
             ->map(function ($page, $site) use ($pageOrigin) {
-                return array_merge($page, [
+                return array_merge($page, array_filter([
                     'origin' => $pageOrigin['id'],
                     'id' => $this->generateUuid($pageOrigin, $site),
                     'slug' => $page['slug'] ?? $pageOrigin['slug'],
                     'fieldset' => $pageOrigin['fieldset'] ?? null,
-                ]);
+                ]));
             })
             ->each(function ($page, $site) {
                 $this->localizedEntries[$site][] = $page;

--- a/src/PagesMigrator.php
+++ b/src/PagesMigrator.php
@@ -105,6 +105,9 @@ class PagesMigrator extends Migrator
         $entry = $page['id'];
 
         $children = collect($this->files->directories($folder))
+            ->sortBy(function ($folder) {
+                return str_replace('/_', '/', $folder);
+            })
             ->map(function ($folder) use ($key, $entry) {
                 return $this->parsePageFolder($folder, "{$key}.{$entry}");
             })

--- a/tests/Fixtures/site-localized/content/pages/6.only-english/fr.index.md
+++ b/tests/Fixtures/site-localized/content/pages/6.only-english/fr.index.md
@@ -1,0 +1,2 @@
+id: 72c016c6-cc0a-4928-b53b-3275f3f6da0a
+published: false

--- a/tests/Fixtures/site-localized/content/pages/6.only-english/index.md
+++ b/tests/Fixtures/site-localized/content/pages/6.only-english/index.md
@@ -1,0 +1,17 @@
+---
+title: 'Only English'
+fun_facts:
+  - 'I grew up in West Virginia but moved to California in the mid 90s'
+  - 'My life is about as organized as the $5 DVD bin at Wal-Mart'
+  - 'My first computer was a Commodore 64'
+  - 'I''m a paper cut survivor'
+  - 'I have a restraining order against me from J.K. Rowling but I promise it''s just a misunderstanding'
+  - 'I hope one day I love something the way women in commercials love yogurt'
+  - 'I’m not smart. I just wear glasses.'
+template: about
+fieldset: about
+id: 72c016c6-cc0a-4928-b53b-3275f3f6da0a
+---
+My name is Niles Peppertrout. I am a relatively new Park Ranger working at Redwood Nation Park with a background in Applied Harry Potter Sciences from [Frostburg University](http://frostburg.edu). I've always loved the outdoors but never dreamed I'd get paid to wander them. [Join me on my adventure](/blog)!
+
+![Me](/assets/img/me.jpg)

--- a/tests/Fixtures/site-localized/content/pages/8.published-in-both/index.md
+++ b/tests/Fixtures/site-localized/content/pages/8.published-in-both/index.md
@@ -1,0 +1,3 @@
+title: Both
+fieldset: default
+id: 56b5f7a0-adcd-4490-bcaa-dad3b8feef6d

--- a/tests/Fixtures/site-localized/content/pages/_7.only-french/fr.index.md
+++ b/tests/Fixtures/site-localized/content/pages/_7.only-french/fr.index.md
@@ -1,0 +1,2 @@
+id: 3cd2d431-699c-417c-8d57-9183cd17a6fc
+published: true

--- a/tests/Fixtures/site-localized/content/pages/_7.only-french/index.md
+++ b/tests/Fixtures/site-localized/content/pages/_7.only-french/index.md
@@ -1,0 +1,18 @@
+---
+title: 'Only French'
+images:
+  - /assets/img/black-bear-cubs.jpg
+  - /assets/img/redwood-balance.jpg
+  - /assets/img/redwood-james-irvine-trail.jpg
+  - /assets/img/redwood-sign.jpg
+  - /assets/img/redwood-snow.jpg
+  - /assets/img/redwood-sunrise.jpg
+  - /assets/img/stetson.jpg
+  - /assets/img/dangle.jpg
+  - /assets/img/desert.jpg
+  - /assets/img/redwood-north-ridge-trail.jpg
+template: gallery
+fieldset: gallery
+id: 3cd2d431-699c-417c-8d57-9183cd17a6fc
+---
+I like to snap a few photos from time to time. These are those photos.

--- a/tests/Fixtures/site-localized/content/pages/_9.published-in-neither/index.md
+++ b/tests/Fixtures/site-localized/content/pages/_9.published-in-neither/index.md
@@ -1,0 +1,3 @@
+title: Neither
+fieldset: default
+id: 2efee6c0-c3a5-44dc-a3db-a0af7fa73977

--- a/tests/Fixtures/site-localized/settings/theming.yaml
+++ b/tests/Fixtures/site-localized/settings/theming.yaml
@@ -1,0 +1,14 @@
+theme: redwood
+default_layout: default
+default_page_template: default
+default_entry_template: post
+default_taxonomy_template: taxonomy
+error_template_folder: errors
+default_fieldset: default
+default_page_fieldset: page
+default_entry_fieldset: entry
+default_term_fieldset: term
+default_asset_fieldset: asset
+smartypants: false
+allow_php: false
+markdown_hard_wrap: false

--- a/tests/MigrateLocalizedPagesTest.php
+++ b/tests/MigrateLocalizedPagesTest.php
@@ -166,6 +166,7 @@ class MigrateLocalizedPagesTest extends TestCase
             'id' => $frenchEntry['id'],
             'origin' => '60962021-f154-4cd2-a1d7-035a12b6da9e',
             'slug' => 'blog',
+            'published' => true,
         ];
 
         $this->assertEquals($expectedFrenchEntry, $frenchEntry);

--- a/tests/MigrateLocalizedPagesTest.php
+++ b/tests/MigrateLocalizedPagesTest.php
@@ -132,7 +132,7 @@ class MigrateLocalizedPagesTest extends TestCase
     }
 
     /** @test */
-    public function it_can_migrate_a_localized_page()
+    public function it_can_migrate_an_explicitly_localized_page()
     {
         $this->artisan('statamic:migrate:pages');
 
@@ -146,6 +146,31 @@ class MigrateLocalizedPagesTest extends TestCase
         $this->assertNotEquals($defaultEntry['id'], $frenchEntry['id']);
         $this->assertEquals($defaultEntry['id'], $frenchEntry['origin']);
         $this->assertNotNull($frenchEntry['id']);
+        $this->assertArrayNotHasKey('fieldset', $defaultEntry);
+        $this->assertArrayNotHasKey('fieldset', $frenchEntry);
+    }
+
+    /** @test */
+    public function it_can_migrate_an_implicitly_localized_page()
+    {
+        $this->artisan('statamic:migrate:pages');
+
+        $this->assertFileNotExists($this->collectionsPath('pages/blog.md'));
+        $this->assertFileExists($defaultPath = $this->collectionsPath('pages/default/blog.md'));
+        $this->assertFileExists($frenchPath = $this->collectionsPath('pages/fr/blog.md'));
+
+        $defaultEntry = YAML::parse($this->files->get($defaultPath));
+        $frenchEntry = YAML::parse($this->files->get($frenchPath));
+
+        $expectedFrenchEntry = [
+            'id' => $frenchEntry['id'],
+            'origin' => '60962021-f154-4cd2-a1d7-035a12b6da9e',
+            'slug' => 'blog',
+        ];
+
+        $this->assertEquals($expectedFrenchEntry, $frenchEntry);
+        $this->assertNotEquals($defaultEntry['id'], $frenchEntry['id']);
+        $this->assertEquals($defaultEntry['id'], $frenchEntry['origin']);
     }
 
     /** @test */

--- a/tests/MigrateLocalizedPagesTest.php
+++ b/tests/MigrateLocalizedPagesTest.php
@@ -38,17 +38,17 @@ class MigrateLocalizedPagesTest extends TestCase
     public function it_migrates_expected_number_of_files()
     {
         $this->assertCount(2, $this->files->files($this->sitePath('content/pages')));
-        $this->assertCount(5, $this->files->directories($this->sitePath('content/pages')));
+        $this->assertCount(9, $this->files->directories($this->sitePath('content/pages')));
 
         $this->artisan('statamic:migrate:pages');
 
         $this->assertFileExists($this->collectionsPath('pages.yaml'));
 
         $this->assertCount(0, $this->files->files($this->collectionsPath('pages')));
-        $this->assertCount(22, $this->files->allFiles($this->collectionsPath('pages')));
+        $this->assertCount(30, $this->files->allFiles($this->collectionsPath('pages')));
         $this->assertCount(2, $this->files->directories($this->collectionsPath('pages')));
-        $this->assertCount(11, $this->files->files($this->collectionsPath('pages/default')));
-        $this->assertCount(11, $this->files->files($this->collectionsPath('pages/fr')));
+        $this->assertCount(15, $this->files->files($this->collectionsPath('pages/default')));
+        $this->assertCount(15, $this->files->files($this->collectionsPath('pages/fr')));
     }
 
     /** @test */
@@ -95,6 +95,10 @@ class MigrateLocalizedPagesTest extends TestCase
                 ],
                 ['entry' => '26a4ce21-d768-440d-806b-213918df0ee0'],
                 ['entry' => 'de627bca-7595-429e-9b41-ad58703916d7'],
+                ['entry' => '72c016c6-cc0a-4928-b53b-3275f3f6da0a'],
+                ['entry' => '3cd2d431-699c-417c-8d57-9183cd17a6fc'],
+                ['entry' => '56b5f7a0-adcd-4490-bcaa-dad3b8feef6d'],
+                ['entry' => '2efee6c0-c3a5-44dc-a3db-a0af7fa73977'],
             ],
         ];
 
@@ -123,6 +127,10 @@ class MigrateLocalizedPagesTest extends TestCase
                 ],
                 ['entry' => 'fr-26a4ce21-d768-440d-806b-213918df0ee0'],
                 ['entry' => 'fr-de627bca-7595-429e-9b41-ad58703916d7'],
+                ['entry' => 'fr-72c016c6-cc0a-4928-b53b-3275f3f6da0a'],
+                ['entry' => 'fr-3cd2d431-699c-417c-8d57-9183cd17a6fc'],
+                ['entry' => 'fr-56b5f7a0-adcd-4490-bcaa-dad3b8feef6d'],
+                ['entry' => 'fr-2efee6c0-c3a5-44dc-a3db-a0af7fa73977'],
             ],
         ];
 
@@ -199,5 +207,23 @@ class MigrateLocalizedPagesTest extends TestCase
 
         $this->assertParsedYamlContains(['avatar' => 'img/stetson.jpg'], $this->collectionsPath('pages/default/about.md'));
         $this->assertParsedYamlContains(['avatar' => 'img/coffee-mug.jpg'], $this->collectionsPath('pages/fr/les-aboot.md'));
+    }
+
+    /** @test */
+    public function it_can_migrate_localized_published_statuses()
+    {
+        $this->artisan('statamic:migrate:pages');
+
+        $this->assertParsedYamlContains(['published' => true], $this->collectionsPath('pages/default/only-english.md'));
+        $this->assertParsedYamlContains(['published' => false], $this->collectionsPath('pages/fr/only-english.md'));
+
+        $this->assertParsedYamlContains(['published' => false], $this->collectionsPath('pages/default/only-french.md'));
+        $this->assertParsedYamlContains(['published' => true], $this->collectionsPath('pages/fr/only-french.md'));
+
+        $this->assertParsedYamlContains(['published' => true], $this->collectionsPath('pages/default/published-in-both.md'));
+        $this->assertParsedYamlContains(['published' => true], $this->collectionsPath('pages/fr/published-in-both.md'));
+
+        $this->assertParsedYamlContains(['published' => false], $this->collectionsPath('pages/default/published-in-neither.md'));
+        $this->assertParsedYamlContains(['published' => false], $this->collectionsPath('pages/fr/published-in-neither.md'));
     }
 }

--- a/tests/MigrateLocalizedPagesTest.php
+++ b/tests/MigrateLocalizedPagesTest.php
@@ -45,10 +45,10 @@ class MigrateLocalizedPagesTest extends TestCase
         $this->assertFileExists($this->collectionsPath('pages.yaml'));
 
         $this->assertCount(0, $this->files->files($this->collectionsPath('pages')));
-        $this->assertCount(17, $this->files->allFiles($this->collectionsPath('pages')));
+        $this->assertCount(22, $this->files->allFiles($this->collectionsPath('pages')));
         $this->assertCount(2, $this->files->directories($this->collectionsPath('pages')));
         $this->assertCount(11, $this->files->files($this->collectionsPath('pages/default')));
-        $this->assertCount(6, $this->files->files($this->collectionsPath('pages/fr')));
+        $this->assertCount(11, $this->files->files($this->collectionsPath('pages/fr')));
     }
 
     /** @test */
@@ -105,15 +105,24 @@ class MigrateLocalizedPagesTest extends TestCase
                     'entry' => 'fr-72c016c6-cc0a-4928-b53b-3275f3f6da0a',
                     'children' => [
                         ['entry' => 'fr-7f48ceb3-97c5-45be-acd4-f88ff0284ed6'],
+                        ['entry' => 'fr-f748ceb3-97c5-45be-acd4-f88ff0249e71'],
                         ['entry' => 'fr-4ef748b3-97c5-acd4-be45-f8849e71ff02'],
                     ],
                 ],
+                ['entry' => 'fr-60962021-f154-4cd2-a1d7-035a12b6da9e'],
                 [
                     'entry' => 'fr-3cd2d431-699c-417c-8d57-9183cd17a6fc',
                     'children' => [
-                        ['entry' => 'fr-1a45dfed-9d06-4493-83b1-dffe2522cbe7'],
+                        [
+                            'entry' => 'fr-1a45dfed-9d06-4493-83b1-dffe2522cbe7',
+                            'children' => [
+                                ['entry' => 'fr-c50f5ee5-683d-4299-b16c-9271b7f9e41b'],
+                            ],
+                        ],
                     ],
                 ],
+                ['entry' => 'fr-26a4ce21-d768-440d-806b-213918df0ee0'],
+                ['entry' => 'fr-de627bca-7595-429e-9b41-ad58703916d7'],
             ],
         ];
 


### PR DESCRIPTION
- [x] Ensure implicitly localized pages get migrated over with `origin`'s referencing the default site entry's `id`.
- [x] Ensure localized pages use proper fieldsets when migrating content.
- [x] Ensure `published` status is preserved across entries for all sites.
- [x] Ensure entry order is preserved across entries for all sites.

Closes #89.