### PR TITLE
Fix asset migrator failing due to event listeners failing

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
         "mustangostang/spyc": "dev-master#dfd9aadc1f5224065d55b42b712c7e99a50a3f4d"
     },
     "require-dev": {
-        "statamic/cms": "^3.3.0",
+        "statamic/cms": "^3.3.21",
         "mockery/mockery": "^1.4.4",
         "orchestra/testbench": "^6.22.0 || ^7.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,10 @@
     "config": {
         "preferred-install": "dist",
         "sort-packages": true,
-        "optimize-autoloader": true
+        "optimize-autoloader": true,
+        "allow-plugins": {
+            "pixelfear/composer-dist-plugin": true
+        }
     },
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/src/AssetContainerMigrator.php
+++ b/src/AssetContainerMigrator.php
@@ -470,7 +470,7 @@ class AssetContainerMigrator extends Migrator
         }
 
         $container->assets()->each(function ($asset) {
-            $asset->hydrate()->save();
+            $asset->hydrate()->saveQuietly();
         });
     }
 


### PR DESCRIPTION
Fix asset migrator failing due to event listeners failing when users are not yet setup correctly. I figure they shouldn't have to set up users first to migrate old data.

This will allow us to quietly generate asset meta without Statamic's event listeners doing extra unnecessary stuff. Requires https://github.com/statamic/cms/pull/6339 (we should also up the minimum Statamic version requirement in the migrator's composer.json to ensure this change is in core).