### PR TITLE
Fix settings migration regression

### DIFF
--- a/src/Configurator.php
+++ b/src/Configurator.php
@@ -61,7 +61,7 @@ class Configurator
 
         $this->preparePhpCsFixer();
 
-        Process::run([__DIR__.'/../vendor/bin/php-cs-fixer', 'fix', $path, '--rules', $rules]);
+        Process::run(['vendor/bin/php-cs-fixer', 'fix', $path, '--rules', $rules]);
 
         return $this;
     }

--- a/tests/MigrateSiteTest.php
+++ b/tests/MigrateSiteTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests;
 
+use Facades\Statamic\Console\Processes\Process;
 use Statamic\Facades\Path;
 use Statamic\Migrator\Configurator;
 use Statamic\Migrator\YAML;
@@ -54,6 +55,8 @@ class MigrateSiteTest extends TestCase
         $this->files->copyDirectory(__DIR__.'/Fixtures/site', base_path('site'));
         $this->files->copyDirectory(__DIR__.'/Fixtures/assets', base_path('assets'));
         $this->files->copy(__DIR__.'/Fixtures/routes/web.php', $this->paths('routesFile'));
+
+        Process::swap(new \Statamic\Console\Processes\Process(__DIR__.'/../'));
     }
 
     /** @test */


### PR DESCRIPTION
Reverts https://github.com/statamic/migrator/commit/a695b45b380875ac72c33eefed5afb3915846391 in favour of a more proper fix.

Our tests weren't failing because of a broken implementation, but rather because of dependency changes. We already dealt with this kind of issue [over here](https://github.com/statamic/migrator/blob/8b733040ae94efda4aaa66bd2ede052507c7118d/tests/MigrateAssetContainerTest.php#L19), so this PR uses the same technique in our `MigrateSiteTest`. 

Fixes #117