### PR TITLE
Fix process path issue

### DIFF
--- a/src/Configurator.php
+++ b/src/Configurator.php
@@ -61,7 +61,7 @@ class Configurator
 
         $this->preparePhpCsFixer();
 
-        Process::run(['vendor/bin/php-cs-fixer', 'fix', $path, '--rules', $rules]);
+        Process::run([getcwd().'/vendor/bin/php-cs-fixer', 'fix', $path, '--rules', $rules]);
 
         return $this;
     }

--- a/tests/ConfiguratorTest.php
+++ b/tests/ConfiguratorTest.php
@@ -2,7 +2,6 @@
 
 namespace Tests;
 
-use Facades\Statamic\Console\Processes\Process;
 use Statamic\Facades\Path;
 use Statamic\Migrator\Configurator;
 
@@ -15,8 +14,6 @@ class ConfiguratorTest extends TestCase
         $this->files->copy(__DIR__.'/Fixtures/config/configurator-test.php', $this->path());
 
         $this->configurator = Configurator::file('statamic/configurator-test.php');
-
-        Process::swap(new \Statamic\Console\Processes\Process(__DIR__.'/../'));
     }
 
     protected function path()

--- a/tests/MigrateAssetContainerTest.php
+++ b/tests/MigrateAssetContainerTest.php
@@ -2,7 +2,6 @@
 
 namespace Tests;
 
-use Facades\Statamic\Console\Processes\Process;
 use Statamic\Facades\Path;
 use Statamic\Migrator\Configurator;
 use Statamic\Migrator\YAML;
@@ -15,8 +14,6 @@ class MigrateAssetContainerTest extends TestCase
         parent::setUp();
 
         $this->configurator = Configurator::file('filesystems.php');
-
-        Process::swap(new \Statamic\Console\Processes\Process(__DIR__.'/../'));
     }
 
     protected function paths()

--- a/tests/MigrateSettingsTest.php
+++ b/tests/MigrateSettingsTest.php
@@ -2,7 +2,6 @@
 
 namespace Tests;
 
-use Facades\Statamic\Console\Processes\Process;
 use Illuminate\Support\Facades\File;
 
 class MigrateSettingsTest extends TestCase
@@ -19,8 +18,6 @@ class MigrateSettingsTest extends TestCase
     public function setUp(): void
     {
         parent::setUp();
-
-        Process::swap(new \Statamic\Console\Processes\Process(__DIR__.'/../'));
 
         $this->files->copy(__DIR__.'/Fixtures/routes/web.php', $this->paths('routesFile'));
     }

--- a/tests/MigrateSiteTest.php
+++ b/tests/MigrateSiteTest.php
@@ -2,7 +2,6 @@
 
 namespace Tests;
 
-use Facades\Statamic\Console\Processes\Process;
 use Statamic\Facades\Path;
 use Statamic\Migrator\Configurator;
 use Statamic\Migrator\YAML;
@@ -55,8 +54,6 @@ class MigrateSiteTest extends TestCase
         $this->files->copyDirectory(__DIR__.'/Fixtures/site', base_path('site'));
         $this->files->copyDirectory(__DIR__.'/Fixtures/assets', base_path('assets'));
         $this->files->copy(__DIR__.'/Fixtures/routes/web.php', $this->paths('routesFile'));
-
-        Process::swap(new \Statamic\Console\Processes\Process(__DIR__.'/../'));
     }
 
     /** @test */


### PR DESCRIPTION
Use `getcwd()` to more intelligently run php-cs-fixer via absolute path, because tests are failing again.

We initially tried to fix this in https://github.com/statamic/migrator/commit/a695b45b380875ac72c33eefed5afb3915846391, and had to revert in https://github.com/statamic/migrator/pull/118. I think the first solution was a red herring solution though, because `__DIR__.'/../'` might always point to the same absolute path, relative to the cwd.

This fix uses `getcwd()` to figure out the proper cwd, both in context of testbench, but also in context of actually running the command as end user.

# Todo

- [x] Manually test migration in MacOS
- [x] Manually test migration in Windows