### PR TITLE
Add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,35 @@
+name: Bug report
+description: Fill out a bug report to help us improve the Migrator.
+labels: [bug]
+body:
+  - type: textarea
+    attributes:
+      label: Bug description
+      description: What happened? What did you expect to happen? Feel free to drop any screenshots in here.
+      placeholder: I did this thing over here, and saw this error...
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: How to reproduce
+      description: List the steps so we're able to recreate this bug. Bonus points if you can provide an example GitHub repo with this bug reproduced.
+      placeholder: Go here, Type this, Click that, Look over there.
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Logs
+      description: You can paste any relevant logs here, they'll be automatically rendered in code blocks. You can find your logs in `storage/logs`.
+      render: shell
+  - type: textarea
+    attributes:
+      label: Environment
+      description: |
+        Please paste the *full* output of the `php please support:details` command. It gives us some context about your project.
+      render: yaml # the format of the command is close to yaml and gets highlighted nicely
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Additional details
+      description: Fancy setup? Anything else you need to share?

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,6 @@
+blank_issues_enabled: false
+
+contact_links:
+  - name: Statamic Core
+    url: https://github.com/statamic/cms/issues/new/choose
+    about: This repository is for the Migrator. If you're having issues with Statamic itself, please open an issue on the cms repository.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,10 @@
+name: Feature Request
+description: Got an idea for a new feature or improvement in the Migrator? We'd love to hear it!
+labels: [feature request]
+body:
+  - type: textarea
+    attributes:
+      label: Description
+      description: What feature or improvement would you like to see? Feel free to provide as much detail as you can.
+    validations:
+      required: true


### PR DESCRIPTION
This pull request adds issue templates to the repo, ensuring new issues have all the information we need to act on them. Copied from the `importer` repo.