### PR TITLE
Fix multiline arrays

### DIFF
--- a/src/Configurator.php
+++ b/src/Configurator.php
@@ -418,7 +418,7 @@ class Configurator
      */
     protected function varExport($value)
     {
-        $value = VarExporter::export($value);
+        $value = $this->exportMultiline($value);
 
         // Remove numeric keys.
         $value = preg_replace("/(\s*)[0-9]+\s=>\s(.*)/", '$1$2', $value);
@@ -433,5 +433,38 @@ class Configurator
         $value = str_replace("\'", "'", $value);
 
         return $value;
+    }
+
+    /**
+     * Export var as a multiline string.
+     *
+     * VarExporter collapses small scalar arrays onto a single line, so we
+     * handle the array nesting ourselves to keep config files multiline,
+     * delegating only scalar leaves to VarExporter.
+     *
+     * @param  mixed  $value
+     * @param  string  $indent
+     * @return string
+     */
+    protected function exportMultiline($value, $indent = '')
+    {
+        if (! is_array($value)) {
+            return VarExporter::export($value);
+        }
+
+        if ($value === []) {
+            return '[]';
+        }
+
+        $subIndent = $indent.'    ';
+        $isList = array_is_list($value);
+
+        $lines = collect($value)->map(function ($value, $key) use ($isList, $subIndent) {
+            $prefix = $isList ? '' : VarExporter::export($key).' => ';
+
+            return $subIndent.$prefix.$this->exportMultiline($value, $subIndent);
+        });
+
+        return "[\n".$lines->implode(",\n").",\n".$indent.']';
     }
 }


### PR DESCRIPTION
`symfony/var-exporter` v8.1.0 (released 2026-05-29) changed `VarExporter::export()` to collapse
small all-scalar nested arrays onto a single line. This broke `Configurator::varExport()`, which
relied on VarExporter's multiline output before passing the result through php-cs-fixer.

Fixes the issue by replacing the flat `VarExporter::export()` call with a small recursive helper
that always expands arrays one element per line, delegating only scalar leaves to VarExporter for
proper string escaping. The existing regex post-passes and normalization step are unchanged.
